### PR TITLE
SSO Redirect detection without modifying the DOM

### DIFF
--- a/background.js
+++ b/background.js
@@ -339,6 +339,24 @@ chrome.runtime.onMessageExternal.addListener(
         }
     });
 
+//This listens for messages from redirected.js and or removes the localLoginUrl to/from local storage
+chrome.runtime.onMessage.addListener(
+    function(request){
+        if (request.from == 'redirected'){
+            chrome.storage.sync.get(['cbxredirected'], function(result){
+                if (result.cbxredirected) {
+                    if (request.url) {
+                        chrome.storage.local.set({'localLoginUrl': request.url});
+                    } else {
+                        chrome.storage.local.remove('localLoginUrl');
+                    }
+                }
+            });
+        }
+	//allow this to be called asynchonously
+	return true;
+});
+
 
 //Retrieve variables from browser tab, passing them back to popup
 function getBrowserVariables(tid) {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "short_name": "ServiceNow Utils",
     "description": "ServiceNow Productivity tools. (Personal work, not affiliated to ServiceNow)",
     "author": "Arnoud Kooi / arnoudkooi.com",
-    "version": "2.7.2.5",
+    "version": "2.7.2.6",
     "permissions": [
         "activeTab",
         "https://*.service-now.com/*",
@@ -105,9 +105,11 @@
         "inject_parent.js"
     ],
     "manifest_version": 2,
+    "options_page": "options.html",
     "applications": {
         "gecko": {
             "id": "email@arnoudkooi.com"
         }
-    }
+	},
+
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <meta charset="utf-8"/>
+    </head>
+    <body>
+        <form>
+            <h4>Redirection detection</h4>
+                <div id="divredirect" class="input-group">
+                    <label>Enable SSO redirect detection</label>
+                    <input type="checkbox" id="cbxredirect">
+                    </br>
+                </div>
+				</form>
+				<script src="js/jquery.js"></script>
+        <script src="options.js"></script>
+    </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,18 @@
+
+document.addEventListener('DOMContentLoaded', function () {
+
+    $('#cbxredirect').click(function () {
+				// Enable SSO redirect detection checkbox click handler
+        var cbxval = $('#cbxredirect').prop('checked');
+        chrome.storage.sync.set({'cbxredirected': cbxval});
+		});
+
+			//get the value of Enable SSO redirect detection checkbox and set the checkbox to match
+			chrome.storage.sync.get('cbxredirected', function(result){
+        if (result.cbxredirected) {
+            //check the checkbox
+            $('#cbxredirect').attr('checked', true); 
+        }
+		});
+});
+

--- a/popup.html
+++ b/popup.html
@@ -19,6 +19,8 @@
 </head>
 
 <body>
+    <div id="notification">    
+    </div>
     <div id="content">
         <form>
             <input id='tbxactivetab' name='tbxactivetab' value="tababout" class="sync" type="hidden" />

--- a/popup.js
+++ b/popup.js
@@ -38,7 +38,21 @@ document.addEventListener('DOMContentLoaded', function () {
 //setIcon("images/icon32newer.png");
 
     });
-
+    
+    //Check if there is a URL in local storage and display it on the popup
+    chrome.storage.local.get(['localLoginUrl'], function(result){
+        if (result.localLoginUrl) {
+            $('#notification').append('<p>It looks like you got redirected to SSO login, do you want to go back to:<a href="#" id="localLoginUrl">' + result.localLoginUrl + '</a></p>');
+            $('#localLoginUrl').click(function (){
+                //The url was clicked, so redirect the tab to the URL and then hide the link
+                chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+                    chrome.tabs.update(tabs[0].id,{'url': result.localLoginUrl});
+                    chrome.storage.local.remove('localLoginUrl');
+                    $('#notification').empty();
+                });
+            });
+        }
+    });
 });
 
 function setIcon(icon){
@@ -776,5 +790,6 @@ function setDataExplore(nme) {
 
     $('#waitingdataexplore').hide();
 
-}
+    
 
+}

--- a/redirected.js
+++ b/redirected.js
@@ -1,40 +1,32 @@
 (function () {
-	// when being redirected to single sign on, this creates a link back to login.do
+    // When being redirected to Single Sign On generate a link to login.do and keep it in local storage for use by the popup
 
-	//get the request url
-	var oldUrl =  window.location.toString(); 
-	
-	//decode uri component until it stops changing
-	var changed = true;
-	while (changed) { 
-		newUrl = decodeURIComponent(oldUrl);
-		changed = !(newUrl === oldUrl);
-		oldUrl = newUrl;
-	}
+    //get the request url
+    var oldUrl = window.location.toString();
 
-	//extract the instance url from the request url
-	newUrl = oldUrl.replace(/(^.*&RelayState=)(https:\/\/.*\.service-now.com)(.*$)/,'$2/login.do');
-	
-	//create a new element
-	var link = document.createElement("div");
-	link.setAttribute("class", "dedirect");
-	link.innerHTML = '<div>You got redirected, click here to go to <a href="' + newUrl + '">login.do</a><div>';//double level of nesting
-	
-	//insert the new element at the top of the dom
-	//on some SSO pages this will be covered by existing content
-	$(document.body).prepend(link);
+    //decode uri component until it stops changing
+    var changed = true;
+    while (changed) {
+        newUrl = decodeURIComponent(oldUrl);
+        changed = !(newUrl === oldUrl);
+        oldUrl = newUrl;
+    }
 
-	//Wait for the page to finish loading
-	$(document).ready(function(){
-		//move the new element to the end of the DOM
-		$('.dedirect').appendTo(document.body);
+    //regex to test that the decoded url does contain &RelayState= and does not contain auth_redirect or fromURI
+    var regex = /^(?=.*&RelayState=)(?!.*auth_redirect|.*fromURI).*/;
+    if (!regex.test(oldUrl)) {
+        //regex didn't match so send a message to background script to remove the url from local storage
+        chrome.runtime.sendMessage({
+            from: 'redirected'
+        });
+    } else {
+        //regex matched so send a message to background script to add the url to local storage
 
-		//set the position to absolute. The object is now at the front on everything else on page
-		$('.dedirect').css("position","absolute"); 
-
-		//set the top and left to 0px so the link is in the top left corner
-		$('.dedirect').css("left", "0px");
-		$('.dedirect').css("top", "0px");
-
-	});
+        //extract the instance url from the request url
+        newUrl = oldUrl.replace(/(^.*&RelayState=)(https:\/\/.*\.service-now.com)(.*$)/, '$2/login.do');
+        chrome.runtime.sendMessage({
+            from: 'redirected',
+            url: newUrl
+        });
+    }
 })();


### PR DESCRIPTION
Detect SSO Redirection, store the URL, when the popup is loaded retrieve the URL and display a link in the popup. Adds an option page to allow this feature to be disabled.