### PR TITLE
SSO Redirect detection without modifying the DOM

### DIFF
--- a/background.js
+++ b/background.js
@@ -496,6 +496,24 @@ chrome.runtime.onMessageExternal.addListener(
         }
     });
 
+//This listens for messages from redirected.js and or removes the localLoginUrl to/from local storage
+chrome.runtime.onMessage.addListener(
+    function(request){
+        if (request.from == 'redirected'){
+            chrome.storage.sync.get(['cbxredirected'], function(result){
+                if (result.cbxredirected) {
+                    if (request.url) {
+                        chrome.storage.local.set({'localLoginUrl': request.url});
+                    } else {
+                        chrome.storage.local.remove('localLoginUrl');
+                    }
+                }
+            });
+        }
+	//allow this to be called asynchonously
+	return true;
+});
+
 
 //Retrieve variables from browser tab, passing them back to popup
 function getBrowserVariables(tid) {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "short_name": "ServiceNow Utils",
     "description": "ServiceNow Productivity tools. (Personal work, not affiliated to ServiceNow)",
     "author": "Arnoud Kooi / arnoudkooi.com",
-    "version": "2.8.1.0",
+    "version": "2.8.1.1",
     "permissions": [
         "activeTab",
         "https://*.service-now.com/*",
@@ -54,6 +54,16 @@
                 "content_script_all_frames.js"
             ],
             "all_frames": true
+        },
+        {
+            "matches": [
+                    "https://*/*SAMLRequest*service-now.com*",
+                    "https://*/*SAMLRequest*service-now.com"
+            ],
+            "js": [ 
+                    "js/jquery.js",
+                    "redirected.js"
+            ]
         }
     ],
     "commands": {

--- a/options.html
+++ b/options.html
@@ -27,6 +27,15 @@
         <h3>Keyboard shortcuts</h3>
         <p id="chrome_warning">Go to <a class="popuplinks" href="chrome://extensions/shortcuts" target="_blank">chrome://extensions/shortcuts</a> to adjust the extension shortcuts</p>
     </form>
+    <form>
+        <h4>Redirection detection</h4>
+            <div id="divredirect" class="input-group">
+                <label>Enable SSO redirect detection</label>
+                <input type="checkbox" id="cbxredirect">
+                </br>
+            </div>
+	</form>
+	<script src="js/jquery.js"></script>
     <script src="options.js"></script>
 </body>
 

--- a/options.js
+++ b/options.js
@@ -40,7 +40,7 @@ async function createUI() {
         line.appendChild(reset);
         let resetText = document.createTextNode("Reset");
         reset.append(resetText);
-    }
+		}
 }
 
 /**
@@ -78,3 +78,25 @@ async function resetShortcut(e) {
  * Update the UI when the page loads.
  */
 document.addEventListener('DOMContentLoaded', createUI);
+document.addEventListener('DOMContentLoaded', function () {
+
+// Enable SSO redirect detection checkbox click handler
+$('#cbxredirect').click(function () {
+	console.log("JCB running the redirect checkbox click handler");
+	var cbxval = $('#cbxredirect').prop('checked');
+	console.log("JCB saving checkbox state = " + cbxval);
+	chrome.storage.sync.set({'cbxredirected': cbxval});
+});
+
+//get the value of Enable SSO redirect detection checkbox and set the checkbox to match
+console.log("JCB DOMcontentloaded is right");
+chrome.storage.sync.get('cbxredirected', function(result){
+	console.log("JCB retrieved from sync storage cbxredirected = " + JSON.stringify(result));
+	if (result.cbxredirected) {
+			//check the checkbox
+			$('#cbxredirect').attr('checked', true); 
+	}
+});
+
+
+});

--- a/popup.html
+++ b/popup.html
@@ -20,6 +20,7 @@
 </head>
 
 <body>
+		<div id="notification"></div>
     <div id="content">
         <form>
             <input id='tbxactivetab' name='tbxactivetab' value="tababout" class="sync" type="hidden" />

--- a/popup.js
+++ b/popup.js
@@ -39,6 +39,20 @@ document.addEventListener('DOMContentLoaded', function () {
 
     });
     document.querySelector('#firefoxoptions').href = chrome.runtime.getURL("options.html");
+    //Check if there is a URL in local storage and display it on the popup
+    chrome.storage.local.get(['localLoginUrl'], function(result){
+			if (result.localLoginUrl) {
+					$('#notification').append('<p>It looks like you got redirected to SSO login, do you want to go back to:<a href="#" id="localLoginUrl">' + result.localLoginUrl + '</a></p>');
+					$('#localLoginUrl').click(function (){
+							//The url was clicked, so redirect the tab to the URL and then hide the link
+							chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+									chrome.tabs.update(tabs[0].id,{'url': result.localLoginUrl});
+									chrome.storage.local.remove('localLoginUrl');
+									$('#notification').empty();
+							});
+					});
+			}
+	});
 });
 
 function setIcon(icon){

--- a/redirected.js
+++ b/redirected.js
@@ -1,0 +1,32 @@
+(function () {
+    // When being redirected to Single Sign On generate a link to login.do and keep it in local storage for use by the popup
+
+    //get the request url
+    var oldUrl = window.location.toString();
+
+    //decode uri component until it stops changing
+    var changed = true;
+    while (changed) {
+        newUrl = decodeURIComponent(oldUrl);
+        changed = !(newUrl === oldUrl);
+        oldUrl = newUrl;
+    }
+
+    //regex to test that the decoded url does contain &RelayState= and does not contain auth_redirect or fromURI
+    var regex = /^(?=.*&RelayState=)(?!.*auth_redirect|.*fromURI).*/;
+    if (!regex.test(oldUrl)) {
+        //regex didn't match so send a message to background script to remove the url from local storage
+        chrome.runtime.sendMessage({
+            from: 'redirected'
+        });
+    } else {
+        //regex matched so send a message to background script to add the url to local storage
+
+        //extract the instance url from the request url
+        newUrl = oldUrl.replace(/(^.*&RelayState=)(https:\/\/.*\.service-now.com)(.*$)/, '$2/login.do');
+        chrome.runtime.sendMessage({
+            from: 'redirected',
+            url: newUrl
+        });
+    }
+})();


### PR DESCRIPTION
Detect SSO Redirection, store the URL, when the popup is loaded retrieve the URL and display a link in the popup. Adds an option page to allow this feature to be disabled.